### PR TITLE
Adicionando conexão com MySQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
     runtimeOnly "javax.xml.bind:jaxb-api:2.3.1"
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:3.3.4"
+    runtimeOnly "mysql:mysql-connector-java:5.1.48"
     testImplementation "io.micronaut:micronaut-inject-groovy"
     testImplementation "org.grails:grails-gorm-testing-support"
     testImplementation "org.mockito:mockito-core"

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -100,15 +100,18 @@ hibernate:
 dataSource:
     pooled: true
     jmxExport: true
-    driverClassName: org.h2.Driver
-    username: sa
-    password: ''
+    driverClassName: com.mysql.jdbc.Driver
+    dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+    username: <user_here>
+    password: <password_here>
+    dbCreate: update
+    url: jdbc:mysql://127.0.0.1:3306/miniasaas
 
 environments:
     development:
         dataSource:
-            dbCreate: create-drop
-            url: jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+            dbCreate: update
+            url: jdbc:mysql://127.0.0.1:3306/miniasaas
     test:
         dataSource:
             dbCreate: update


### PR DESCRIPTION
## Impacto:

Este PR visa conectar a aplicação ao banco de dados MySQL para que os dados possam ser persistidos mesmo depois do término da aplicação.m

## Tarefa do Jira:
https://miniasaas.atlassian.net/browse/KAN-11

## Cenários testados:
* Payer foi criado, após isso foi verificado se estava no MySQL Workbench.
* Dois Payers foram criados, aplicação parou e foi reiniciada e os dois continuaram lá.

## PR predecessor:
main